### PR TITLE
_.flatten shallow parameter doesn't work as expected

### DIFF
--- a/moses.lua
+++ b/moses.lua
@@ -772,8 +772,8 @@ function _.flatten(array, shallow)
   local new_flattened
   local _flat = {}
   for key,value in pairs(array) do
-    if _.isTable(value) and not shallow then
-      new_flattened = _.flatten (value)
+    if _.isTable(value) then
+      new_flattened = shallow and value or _.flatten (value)
       _.each(new_flattened, function(_,item) _flat[#_flat+1] = item end)
     else _flat[#_flat+1] = value
     end

--- a/moses_min.lua
+++ b/moses_min.lua
@@ -132,8 +132,8 @@ not abb end)end
 function __b.flatten(dab,_bb)local abb=_bb or false
 local bbb;local cbb={}
 for dbb,_cb in cda(dab)do
-if __b.isTable(_cb)and not abb then
-bbb=__b.flatten(_cb)
+if __b.isTable(_cb)then
+bbb=abb and _cb or __b.flatten(_cb)
 __b.each(bbb,function(acb,bcb)cbb[#cbb+1]=bcb end)else cbb[#cbb+1]=_cb end end;return cbb end
 function __b.difference(dab,_bb)if not _bb then return __b.clone(dab)end;return
 __b.select(dab,function(abb,bbb)return not

--- a/specs/array_spec.lua
+++ b/specs/array_spec.lua
@@ -310,8 +310,8 @@ context('Array functions specs', function()
       assert_true(_.isEqual(_.flatten({1,{2,3},{4,5,{6,7}}}),{1,2,3,4,5,6,7}))
     end) 
     
-    test('when given arg "shallow", will do nothing', function()
-      assert_true(_.isEqual(_.flatten({1,{2,3},{4,5,{6,7}}},true),{1,{2,3},{4,5,{6,7}}}))
+    test('when given arg "shallow", flatten only first level', function()
+      assert_true(_.isEqual(_.flatten({1,{2,3},{4,5,{6,7}}},true),{1,2,3,4,5,{6,7}}))
     end)     
     
   end)


### PR DESCRIPTION
The documentation says that _.flatten() should flatten the first level of the array when the "shallow" parameter is set to true. Instead of that, it was doing nothing but simply returning the input array. Now it works as documented, for example {1, {2, {3}}} becomes {1, 2, {3}}
