### PR TITLE
Map key-value pairs to key-value pairs.

### DIFF
--- a/moses.lua
+++ b/moses.lua
@@ -182,7 +182,8 @@ end
 function _.map(t, f, ...)
   local _t = {}
   for index,value in pairs(t) do
-    _t[index] = f(index,value,...)
+    local k, kv, v = index, f(index,value,...)
+    _t[v and kv or k] = v or kv
   end
   return _t
 end

--- a/spec/table_spec.lua
+++ b/spec/table_spec.lua
@@ -174,6 +174,12 @@ context('Table functions specs', function()
           return k..v 
         end),{a = 'a1',b = 'b2'}))
     end)
+
+    test('maps key-value pairs to key-value pairs', function()
+      assert_true(_.isEqual(_.map({a = 1, b = 2}, function(k, v)
+          return k .. k, v + 10
+        end), {aa = 11, bb = 12}))
+    end)
     
   end)
   


### PR DESCRIPTION
A useful feature that I found missing from Moses. Not sure if this is the best way to implement it though, maybe it would work better as a separate function, e.g. `map_pairs`.
