### PR TITLE
Fix issue where functions passed into _.compose could be run twice

### DIFF
--- a/moses.lua
+++ b/moses.lua
@@ -1182,7 +1182,11 @@ function _.compose(...)
   return function (...)
       local _temp
       for i, func in ipairs(f) do
-        _temp = _temp and func(_temp) or func(...)
+        if not _temp then
+          _temp = func(...)
+        else
+          _temp = func(_temp)
+        end
       end
       return _temp
     end


### PR DESCRIPTION
If the last in the chain of functions passed to compose doesn't
return a value (i.e returning a falsy value) then it will be run
twice in a row.

Like so:

```
duplicate(value)
    value = value * 2
    print(value)
    return value
end

saveToDisk(value)
    print(value)
    doSaveOperation()
end

duplicateAndSave = _.compose(saveToDisk, duplicate)

duplicateAndSave(10)

> 20
> 20
> 10
```
