### PR TITLE
Adds _.bind2nd

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1079,6 +1079,15 @@ local sqrt2 = _.bind(math.sqrt,2)
 sqrt2() -- => 1.4142135623731
 ````
 
+### bind2 (f, v)
+
+Binds a value to be the second argument to a function.
+
+```lua
+local last2 = _.bind(_.last,2)
+last2({1,2,3,4,5,6}) -- => {5,6}
+````
+
 ### bindn (f, ...)
 
 Binds a variable number of values to be the first arguments to a function.

--- a/moses.lua
+++ b/moses.lua
@@ -1270,6 +1270,19 @@ function _.bind(f, v)
     end
 end
 
+--- Binds `v` to be the second argument to function `f`. As a result,
+-- calling `f(a, ...)` will result to `f(a, v, ...)`.
+-- @name bind2
+-- @tparam function f a function
+-- @tparam value v a value
+-- @treturn function a function
+-- @see bindn
+function _.bind2(f, v)
+  return function (t, ...)
+    return f(t, v, ...)
+  end
+end
+
 --- Binds `...` to be the N-first arguments to function `f`. As a result,
 -- calling `f(a1, a2, ..., aN)` will result to `f(..., a1, a2, ...,aN)`.
 -- @name bindn

--- a/moses_min.lua
+++ b/moses_min.lua
@@ -196,6 +196,7 @@ function aab.wrap(bcb,ccb)return function(...)return
 ccb(bcb,...)end end
 function aab.times(bcb,ccb,...)local dcb={}for i=1,bcb do dcb[i]=ccb(i,...)end;return dcb end
 function aab.bind(bcb,ccb)return function(...)return bcb(ccb,...)end end
+function aab.bind2(bcb,ccb)return function(t, ...)return bcb(t, ccb, ...)end end
 function aab.bindn(bcb,...)local ccb={...}return function(...)
 return bcb(c_b(aab.append(ccb,{...})))end end
 function aab.uniqueId(bcb,...)acb=acb+1

--- a/spec/func_spec.lua
+++ b/spec/func_spec.lua
@@ -193,6 +193,16 @@ context('Utility functions specs', function()
     
   end) 
 
+  context('bind2', function()
+  
+    test('binds a value to the second arg of a function',function()
+      local last2 = _.bind2(_.last,2)
+      local r = last2({1,2,3,4,5,6})
+      assert_true(_.isEqual(r, {5,6}))
+    end)
+    
+  end)
+
   context('bindn', function()
   
     test('binds n values to as the n-first args of a function',function()


### PR DESCRIPTION
Similar to `_.bind`, but binds a value to the second argument of the function.
I found myself in need of something like this mostly when using _.compose and functions like _.last.

Now I'm able to write things like:

``` lua
local last2 = _.bind2nd(_.last, 2)
_.compose(last2, _.compact)
```
