### PR TITLE
Preserve order on table filtering (select)

### DIFF
--- a/moses.lua
+++ b/moses.lua
@@ -319,11 +319,12 @@ end
 -- @treturn table the selected values
 -- @see reject
 function _.select(t, f, ...)
-  local _mapped = _.map(t, f, ...)
-  local _t = {}
-  for index,value in pairs(_mapped) do
-    if value then _t[#_t+1] = t[index] end
-  end
+   local _t = {}
+   for index,value in pairs(t) do
+      if (f(index, value, ...)) then
+         _t[#_t+1] = t[index]
+          end
+     end
   return _t
 end
 

--- a/spec/table_spec.lua
+++ b/spec/table_spec.lua
@@ -335,6 +335,21 @@ context('Table functions specs', function()
           return (value%2~=0)
         end),{1,3,5,7}))        
     end)
+
+    test('order of items is preserved', function()
+      local collection = { "wk_infant", "wk_armor", "wk_min", "wk_artil", "wk_antiair",
+        "wk_antitank", "wk_engeneer", "wk_transp", "wk_fighter", "wk_bomb", "wk_airrecon",
+        "wk_airtrans", "wk_helicopter", "wk_aerostat", "wk_hq", "wk_fort" }
+      local exists = {
+         wk_transp   = true,
+         wk_antitank = true,
+         wk_armor    = true,
+      }
+      local filtered = _.select(collection, function(key,value)
+        return exists[value]
+      end)
+      assert_true(_.isEqual(filtered,{"wk_armor","wk_antitank","wk_transp"}))
+    end)
     
   end) 
    


### PR DESCRIPTION
Hello!

Thanks for the great module!

I think it would be nice to preserve order on "select" call, because on default it doesn't do that (see my test).

WBR, basiliscos
