### PR TITLE
Implemented fix for _.min and _.max

### DIFF
--- a/moses.lua
+++ b/moses.lua
@@ -44,8 +44,10 @@ local function extract(list,comp,transform,...) -- extracts value from a list
       prev = transform(value,...)
     else
       curr = transform(value,...)
-      _ans = comp(prev, curr) and _ans or value
-      prev = curr
+      if comp(curr, prev) then
+        _ans = value
+        prev = curr
+      end
     end
   end
   return _ans

--- a/moses.lua
+++ b/moses.lua
@@ -36,13 +36,16 @@ local function count(t)  -- raw count of items in an map-table
 end
 
 local function extract(list,comp,transform,...) -- extracts value from a list
-  local _ans
+  local _ans, prev, curr
   local transform = transform or _.identity
-  for index,value in pairs(list) do
-    if not _ans then _ans = transform(value,...)
+  for index, value in pairs(list) do
+    if not _ans then 
+      _ans = value
+      prev = transform(value,...)
     else
-      local value = transform(value,...)
-      _ans = comp(_ans,value) and _ans or value
+      curr = transform(value,...)
+      _ans = comp(prev, curr) and _ans or value
+      prev = curr
     end
   end
   return _ans

--- a/spec/table_spec.lua
+++ b/spec/table_spec.lua
@@ -442,7 +442,7 @@ context('Table functions specs', function()
         {name = 'John', age = 23},{name = 'Peter', age = 17},
         {name = 'Steve', age = 15},{age = 33}}        
       assert_equal(_.max(_.pluck(peoples,'age')),33)
-      assert_equal(_.max(peoples,function(people) return people.age end),33)        
+      assert_equal(_.max(peoples,function(people) return people.age end),peoples[4])        
     end)
     
     test('directly compares items when given no iterator', function()
@@ -458,7 +458,7 @@ context('Table functions specs', function()
         {name = 'John', age = 23},{name = 'Peter', age = 17},
         {name = 'Steve', age = 15},{age = 33}}        
       assert_equal(_.min(_.pluck(peoples,'age')),15)
-      assert_equal(_.min(peoples,function(people) return people.age end),15)        
+      assert_equal(_.min(peoples,function(people) return people.age end),peoples[3])        
     end)
     
     test('directly compares items when given no iterator', function()


### PR DESCRIPTION
I found an issue with _.min and _.max when you pass in a transformer function.

Current behaviour will return the min / max value returned by the transformer instead of just using that value for comparison and returning the original value being iterated - this is different to what lodash, underscore and their lua ports do so I assume it's not by design:

```lua
local table = {
  { num = 5, name = 'Bob' },
  { num = 1, name = 'Fred' }
}

local minEntry = _.min(table, function(value)
  return value.num
end)

-- currently: minEntry == 1
-- expected: minEntry == { num = 1, name = 'Fred' }
```