### PR TITLE
Update ldoc.css to pass WMF stylelint defs

### DIFF
--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -120,7 +120,7 @@ body {
 	margin-left: 1em;
 	margin-right: 1em;
 	font-family: 'arial', 'helvetica', 'geneva', sans-serif;
-	background-color: #ffffff;
+	background-color: #fff;
 	margin: 0;
 }
 
@@ -186,7 +186,7 @@ a:link {
 }
 a:visited {
 	font-weight: bold;
-	color: #006699;
+	color: #069;
 	text-decoration: none;
 }
 a:link:hover {
@@ -194,7 +194,7 @@ a:link:hover {
 }
 
 hr {
-	color: #cccccc;
+	color: #ccc;
 	background: #00007f;
 	height: 1px;
 }
@@ -214,7 +214,7 @@ p.name {
 
 pre {
 	background-color: rgb(245, 245, 245);
-	border: 1px solid #C0C0C0; /* silver */
+	border: 1px solid #c0c0c0; /* silver */
 	padding: 10px;
 	margin: 10px 0 10px 0;
 	overflow: auto;
@@ -241,8 +241,8 @@ table.index td {
 
 #product {
 	text-align: center;
-	border-bottom: 1px solid #cccccc;
-	background-color: #ffffff;
+	border-bottom: 1px solid #ccc;
+	background-color: #fff;
 }
 
 #product big {
@@ -251,7 +251,7 @@ table.index td {
 
 #main {
 	background-color: #f0f0f0;
-	border-left: 2px solid #cccccc;
+	border-left: 2px solid #ccc;
 }
 
 #navigation {
@@ -265,11 +265,11 @@ table.index td {
 #navigation h2 {
 	background-color: #e7e7e7;
 	font-size: 1.1em;
-	color: #000000;
+	color: #000;
 	text-align: left;
 	padding: 0.2em;
-	border-top: 1px solid #dddddd;
-	border-bottom: 1px solid #dddddd;
+	border-top: 1px solid #ddd;
+	border-bottom: 1px solid #ddd;
 }
 
 #navigation ul
@@ -293,16 +293,16 @@ table.index td {
 	margin-left: 14em;
 	padding: 1em;
 	width: 700px;
-	border-left: 2px solid #cccccc;
-	border-right: 2px solid #cccccc;
-	background-color: #ffffff;
+	border-left: 2px solid #ccc;
+	border-right: 2px solid #ccc;
+	background-color: #fff;
 }
 
 #about {
 	clear: both;
 	padding: 5px;
-	border-top: 2px solid #cccccc;
-	background-color: #ffffff;
+	border-top: 2px solid #ccc;
+	background-color: #fff;
 }
 
 @media print {
@@ -316,19 +316,19 @@ table.index td {
 	}
 
 	#main {
-		background-color: #ffffff;
+		background-color: #fff;
 		border-left: 0;
 	}
 
 	#container {
 		margin-left: 2%;
 		margin-right: 2%;
-		background-color: #ffffff;
+		background-color: #fff;
 	}
 
 	#content {
 		padding: 1em;
-		background-color: #ffffff;
+		background-color: #fff;
 	}
 
 	#navigation {
@@ -344,14 +344,14 @@ table.index td {
 table.module_list {
 	border-width: 1px;
 	border-style: solid;
-	border-color: #cccccc;
+	border-color: #ccc;
 	border-collapse: collapse;
 }
 table.module_list td {
 	border-width: 1px;
 	padding: 3px;
 	border-style: solid;
-	border-color: #cccccc;
+	border-color: #ccc;
 }
 table.module_list td.name {
 	background-color: #f0f0f0;
@@ -365,14 +365,14 @@ table.module_list td.summary {
 table.function_list {
 	border-width: 1px;
 	border-style: solid;
-	border-color: #cccccc;
+	border-color: #ccc;
 	border-collapse: collapse;
 }
 table.function_list td {
 	border-width: 1px;
 	padding: 3px;
 	border-style: solid;
-	border-color: #cccccc;
+	border-color: #ccc;
 }
 table.function_list td.name {
 	background-color: #f0f0f0;
@@ -415,7 +415,7 @@ ul ol {
 
 /* make the target distinct; helps when we're navigating to a function */
 a:target + * {
-	background-color: #FF9;
+	background-color: #ff9;
 }
 
 

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -6,8 +6,8 @@ http://developer.yahoo.com/yui/license.html
 version: 2.8.2r1
 */
 html {
-	color: #000;
 	background: #FFF;
+	color: #000;
 }
 body,
 div,
@@ -117,11 +117,11 @@ select {
 /* END RESET */
 
 body {
+	background-color: #fff;
+	font-family: 'arial', 'helvetica', 'geneva', sans-serif;
+	margin: 0;
 	margin-left: 1em;
 	margin-right: 1em;
-	font-family: 'arial', 'helvetica', 'geneva', sans-serif;
-	background-color: #fff;
-	margin: 0;
 }
 
 code, tt {
@@ -141,8 +141,8 @@ span.types:after {
 	content: ')';
 }
 .type {
-	font-weight: bold;
 	font-style: italic;
+	font-weight: bold;
 }
 
 body, p, td, th {
@@ -180,13 +180,13 @@ h4 {
 }
 
 a:link {
-	font-weight: bold;
 	color: #004080;
+	font-weight: bold;
 	text-decoration: none;
 }
 a:visited {
-	font-weight: bold;
 	color: #069;
+	font-weight: bold;
 	text-decoration: none;
 }
 a:link:hover {
@@ -194,8 +194,8 @@ a:link:hover {
 }
 
 hr {
-	color: #ccc;
 	background: #00007f;
+	color: #ccc;
 	height: 1px;
 }
 
@@ -215,10 +215,10 @@ p.name {
 pre {
 	background-color: rgb(245, 245, 245);
 	border: 1px solid #c0c0c0; /* silver */
-	padding: 10px;
+	font-family: 'Andale Mono', monospace;
 	margin: 10px 0 10px 0;
 	overflow: auto;
-	font-family: 'Andale Mono', monospace;
+	padding: 10px;
 }
 
 pre.example {
@@ -234,15 +234,15 @@ table.index td {
 }
 
 #container {
+	background-color: #f0f0f0;
 	margin-left: 1em;
 	margin-right: 1em;
-	background-color: #f0f0f0;
 }
 
 #product {
-	text-align: center;
-	border-bottom: 1px solid #ccc;
 	background-color: #fff;
+	border-bottom: 1px solid #ccc;
+	text-align: center;
 }
 
 #product big {
@@ -255,21 +255,21 @@ table.index td {
 }
 
 #navigation {
-	float: left;
-	width: 14em;
-	vertical-align: top;
 	background-color: #f0f0f0;
+	float: left;
 	overflow: visible;
+	vertical-align: top;
+	width: 14em;
 }
 
 #navigation h2 {
 	background-color: #e7e7e7;
-	font-size: 1.1em;
-	color: #000;
-	text-align: left;
-	padding: 0.2em;
-	border-top: 1px solid #ddd;
 	border-bottom: 1px solid #ddd;
+	border-top: 1px solid #ddd;
+	color: #000;
+	font-size: 1.1em;
+	padding: 0.2em;
+	text-align: left;
 }
 
 #navigation ul
@@ -280,9 +280,9 @@ table.index td {
 }
 
 #navigation li {
-	text-indent: -1em;
 	display: block;
 	margin: 3px 0 0 22px;
+	text-indent: -1em;
 }
 
 #navigation li li a {
@@ -290,19 +290,19 @@ table.index td {
 }
 
 #content {
+	background-color: #fff;
+	border-left: 2px solid #ccc;
+	border-right: 2px solid #ccc;
 	margin-left: 14em;
 	padding: 1em;
 	width: 700px;
-	border-left: 2px solid #ccc;
-	border-right: 2px solid #ccc;
-	background-color: #fff;
 }
 
 #about {
+	background-color: #fff;
+	border-top: 2px solid #ccc;
 	clear: both;
 	padding: 5px;
-	border-top: 2px solid #ccc;
-	background-color: #fff;
 }
 
 @media print {
@@ -310,8 +310,8 @@ table.index td {
 		font: 12pt 'Times New Roman', 'TimeNR', 'Times', serif;
 	}
 	a {
-		font-weight: bold;
 		color: #004080;
+		font-weight: bold;
 		text-decoration: underline;
 	}
 
@@ -321,14 +321,14 @@ table.index td {
 	}
 
 	#container {
+		background-color: #fff;
 		margin-left: 2%;
 		margin-right: 2%;
-		background-color: #fff;
 	}
 
 	#content {
-		padding: 1em;
 		background-color: #fff;
+		padding: 1em;
 	}
 
 	#navigation {
@@ -342,16 +342,16 @@ table.index td {
 }
 
 table.module_list {
-	border-width: 1px;
-	border-style: solid;
-	border-color: #ccc;
 	border-collapse: collapse;
+	border-color: #ccc;
+	border-style: solid;
+	border-width: 1px;
 }
 table.module_list td {
+	border-color: #ccc;
+	border-style: solid;
 	border-width: 1px;
 	padding: 3px;
-	border-style: solid;
-	border-color: #ccc;
 }
 table.module_list td.name {
 	background-color: #f0f0f0;
@@ -363,16 +363,16 @@ table.module_list td.summary {
 
 
 table.function_list {
-	border-width: 1px;
-	border-style: solid;
-	border-color: #ccc;
 	border-collapse: collapse;
+	border-color: #ccc;
+	border-style: solid;
+	border-width: 1px;
 }
 table.function_list td {
+	border-color: #ccc;
+	border-style: solid;
 	border-width: 1px;
 	padding: 3px;
-	border-style: solid;
-	border-color: #ccc;
 }
 table.function_list td.name {
 	background-color: #f0f0f0;
@@ -392,8 +392,8 @@ dl.table dt, dl.function dt {
 	padding-top: 1em;
 }
 dl.table dd, dl.function dd {
-	padding-bottom: 1em;
 	margin: 10px 0 0 20px;
+	padding-bottom: 1em;
 }
 dl.table h3, dl.function h3 {
 	font-size: .95em;
@@ -437,8 +437,8 @@ pre .library {
 	color: #0e7c6b;
 }
 pre .marker {
-	color: #512b1e;
 	background: #fedc56;
+	color: #512b1e;
 	font-weight: bold;
 }
 pre .string {

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -126,7 +126,8 @@ body {
 	margin: 0 1em 0 1em;
 }
 
-code, tt {
+code,
+tt {
 	font-family: monospace;
 	font-size: 1.1em;
 }
@@ -221,7 +222,7 @@ p.name {
 }
 
 pre {
-	background-color: rgb(245, 245, 245);
+	background-color: rgb( 245, 245, 245 );
 	border: 1px solid #c0c0c0; /* silver */
 	font-family: 'Andale Mono', monospace;
 	margin: 10px 0 10px 0;

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -9,7 +9,32 @@ html {
     color: #000;
     background: #FFF;
 }
-body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,button,textarea,p,blockquote,th,td {
+body,
+div,
+dl,
+dt,
+dd,
+ul,
+ol,
+li,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+pre,
+code,
+form,
+fieldset,
+legend,
+input,
+button,
+textarea,
+p,
+blockquote,
+th,
+td {
     margin: 0;
     padding: 0;
 }
@@ -17,30 +42,49 @@ table {
     border-collapse: collapse;
     border-spacing: 0;
 }
-fieldset,img {
+fieldset,
+img {
     border: 0;
 }
-address,caption,cite,code,dfn,em,strong,th,var,optgroup {
+address,
+caption,
+cite,
+code,
+dfn,
+em,
+strong,
+th,
+var,
+optgroup {
     font-style: inherit;
     font-weight: inherit;
 }
-del,ins {
+del,
+ins {
     text-decoration: none;
 }
 li {
     margin-left: 20px;
 }
-caption,th {
+caption,
+th {
     text-align: left;
 }
-h1,h2,h3,h4,h5,h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
     font-size: 100%;
     font-weight: bold;
 }
-q:before,q:after {
+q:before,
+q:after {
     content: '';
 }
-abbr,acronym {
+abbr,
+acronym {
     border: 0;
     font-variant: normal;
 }
@@ -53,13 +97,21 @@ sub {
 legend {
     color: #000;
 }
-input,button,textarea,select,optgroup,option {
+input,
+button,
+textarea,
+select,
+optgroup,
+option {
     font-family: inherit;
     font-size: inherit;
     font-style: inherit;
     font-weight: inherit;
 }
-input,button,textarea,select {*font-size:100%;
+input,
+button,
+textarea,
+select {*font-size:100%;
 }
 /* END RESET */
 

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -119,7 +119,7 @@ select {
 body {
 	margin-left: 1em;
 	margin-right: 1em;
-	font-family: arial, helvetica, geneva, sans-serif;
+	font-family: 'arial', 'helvetica', 'geneva', sans-serif;
 	background-color: #ffffff;
 	margin: 0;
 }

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -111,7 +111,8 @@ option {
 input,
 button,
 textarea,
-select {*font-size: 100%;
+select {
+	*font-size: 100%;
 }
 /* END RESET */
 
@@ -119,36 +120,78 @@ body {
 	margin-left: 1em;
 	margin-right: 1em;
 	font-family: arial, helvetica, geneva, sans-serif;
-	background-color: #ffffff; margin: 0px;
+	background-color: #ffffff;
+	margin: 0px;
 }
 
-code, tt { font-family: monospace; font-size: 1.1em; }
-span.parameter { font-family: monospace; }
-span.parameter:after { content: ":"; }
-span.types:before { content: "("; }
-span.types:after { content: ")"; }
-.type { font-weight: bold; font-style: italic }
+code, tt {
+	font-family: monospace;
+	font-size: 1.1em;
+}
+span.parameter {
+	font-family: monospace;
+}
+span.parameter:after {
+	content: ":";
+}
+span.types:before {
+	content: "(";
+}
+span.types:after {
+	content: ")";
+}
+.type {
+	font-weight: bold;
+	font-style: italic;
+}
 
-body, p, td, th { font-size: .95em; line-height: 1.2em;}
+body, p, td, th {
+	font-size: .95em;
+	line-height: 1.2em;
+}
 
-p, ul { margin: 10px 0 0 0px;}
+p, ul {
+	margin: 10px 0 0 0px;
+}
 
-strong { font-weight: bold;}
+strong {
+	font-weight: bold;
+}
 
-em { font-style: italic;}
+em {
+	font-style: italic;
+}
 
 h1 {
 	font-size: 1.5em;
 	margin: 20px 0 20px 0;
 }
-h2, h3, h4 { margin: 15px 0 10px 0; }
-h2 { font-size: 1.25em; }
-h3 { font-size: 1.15em; }
-h4 { font-size: 1.06em; }
+h2, h3, h4 {
+	margin: 15px 0 10px 0;
+}
+h2 {
+	font-size: 1.25em;
+}
+h3 {
+	font-size: 1.15em;
+}
+h4 {
+	font-size: 1.06em;
+}
 
-a:link { font-weight: bold; color: #004080; text-decoration: none; }
-a:visited { font-weight: bold; color: #006699; text-decoration: none; }
-a:link:hover { text-decoration: underline; }
+a:link {
+	font-weight: bold;
+	color: #004080;
+	text-decoration: none;
+}
+a:visited {
+	font-weight: bold;
+	color: #006699;
+	text-decoration: none;
+}
+a:link:hover {
+	text-decoration: underline;
+}
 
 hr {
 	color: #cccccc;
@@ -156,9 +199,13 @@ hr {
 	height: 1px;
 }
 
-blockquote { margin-left: 3em; }
+blockquote {
+	margin-left: 3em;
+}
 
-ul { list-style-type: disc; }
+ul {
+	list-style-type: disc;
+}
 
 p.name {
 	font-family: "Andale Mono", monospace;
@@ -178,8 +225,13 @@ pre.example {
 	font-size: .85em;
 }
 
-table.index { border: 1px #00007f; }
-table.index td { text-align: left; vertical-align: top; }
+table.index {
+	border: 1px #00007f;
+}
+table.index td {
+	text-align: left;
+	vertical-align: top;
+}
 
 #container {
 	margin-left: 1em;
@@ -257,7 +309,11 @@ table.index td { text-align: left; vertical-align: top; }
 	body {
 		font: 12pt "Times New Roman", "TimeNR", Times, serif;
 	}
-	a { font-weight: bold; color: #004080; text-decoration: underline; }
+	a {
+		font-weight: bold;
+		color: #004080;
+		text-decoration: underline;
+	}
 
 	#main {
 		background-color: #ffffff;
@@ -297,8 +353,13 @@ table.module_list td {
 	border-style: solid;
 	border-color: #cccccc;
 }
-table.module_list td.name { background-color: #f0f0f0; min-width: 200px; }
-table.module_list td.summary { width: 100%; }
+table.module_list td.name {
+	background-color: #f0f0f0;
+	min-width: 200px;
+}
+table.module_list td.summary {
+	width: 100%;
+}
 
 
 table.function_list {
@@ -313,23 +374,44 @@ table.function_list td {
 	border-style: solid;
 	border-color: #cccccc;
 }
-table.function_list td.name { background-color: #f0f0f0; min-width: 200px; }
-table.function_list td.summary { width: 100%; }
+table.function_list td.name {
+	background-color: #f0f0f0;
+	min-width: 200px;
+}
+table.function_list td.summary {
+	width: 100%;
+}
 
 ul.nowrap {
 	overflow: auto;
 	white-space: nowrap;
 }
 
-dl.table dt, dl.function dt {border-top: 1px solid #ccc; padding-top: 1em;}
-dl.table dd, dl.function dd {padding-bottom: 1em; margin: 10px 0 0 20px;}
-dl.table h3, dl.function h3 {font-size: .95em;}
+dl.table dt, dl.function dt {
+	border-top: 1px solid #ccc;
+	padding-top: 1em;
+}
+dl.table dd, dl.function dd {
+	padding-bottom: 1em;
+	margin: 10px 0 0 20px;
+}
+dl.table h3, dl.function h3 {
+	font-size: .95em;
+}
 
 /* stop sublists from having initial vertical space */
-ul ul { margin-top: 0px; }
-ol ul { margin-top: 0px; }
-ol ol { margin-top: 0px; }
-ul ol { margin-top: 0px; }
+ul ul {
+	margin-top: 0px;
+}
+ol ul {
+	margin-top: 0px;
+}
+ol ol {
+	margin-top: 0px;
+}
+ul ol {
+	margin-top: 0px;
+}
 
 /* make the target distinct; helps when we're navigating to a function */
 a:target + * {
@@ -338,18 +420,51 @@ a:target + * {
 
 
 /* styles for prettification of source */
-pre .comment { color: #558817; }
-pre .constant { color: #a8660d; }
-pre .escape { color: #844631; }
-pre .keyword { color: #aa5050; font-weight: bold; }
-pre .library { color: #0e7c6b; }
-pre .marker { color: #512b1e; background: #fedc56; font-weight: bold; }
-pre .string { color: #8080ff; }
-pre .number { color: #f8660d; }
-pre .operator { color: #2239a8; font-weight: bold; }
-pre .preprocessor, pre .prepro { color: #a33243; }
-pre .global { color: #800080; }
-pre .user-keyword { color: #800080; }
-pre .prompt { color: #558817; }
-pre .url { color: #272fc2; text-decoration: underline; }
+pre .comment {
+	color: #558817;
+}
+pre .constant {
+	color: #a8660d;
+}
+pre .escape {
+	color: #844631;
+}
+pre .keyword {
+	color: #aa5050;
+	font-weight: bold;
+}
+pre .library {
+	color: #0e7c6b;
+}
+pre .marker {
+	color: #512b1e;
+	background: #fedc56;
+	font-weight: bold;
+}
+pre .string {
+	color: #8080ff;
+}
+pre .number {
+	color: #f8660d;
+}
+pre .operator {
+	color: #2239a8;
+	font-weight: bold;
+}
+pre .preprocessor, pre .prepro {
+	color: #a33243;
+}
+pre .global {
+	color: #800080;
+}
+pre .user-keyword {
+	color: #800080;
+}
+pre .prompt {
+	color: #558817;
+}
+pre .url {
+	color: #272fc2;
+	text-decoration: underline;
+}
 

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -149,12 +149,16 @@ span.types:after {
 	font-weight: bold;
 }
 
-body, p, td, th {
+body,
+p,
+td,
+th {
 	font-size: .95em;
 	line-height: 1.2em;
 }
 
-p, ul {
+p,
+ul {
 	margin: 10px 0 0 0;
 }
 
@@ -170,7 +174,9 @@ h1 {
 	font-size: 1.5em;
 	margin: 20px 0 20px 0;
 }
-h2, h3, h4 {
+h2,
+h3,
+h4 {
 	margin: 15px 0 10px 0;
 }
 h2 {
@@ -391,15 +397,18 @@ ul.nowrap {
 	white-space: nowrap;
 }
 
-dl.table dt, dl.function dt {
+dl.table dt,
+dl.function dt {
 	border-top: 1px solid #ccc;
 	padding-top: 1em;
 }
-dl.table dd, dl.function dd {
+dl.table dd,
+dl.function dd {
 	margin: 10px 0 0 20px;
 	padding-bottom: 1em;
 }
-dl.table h3, dl.function h3 {
+dl.table h3,
+dl.function h3 {
 	font-size: .95em;
 }
 
@@ -455,7 +464,8 @@ pre .operator {
 	color: #2239a8;
 	font-weight: bold;
 }
-pre .preprocessor, pre .prepro {
+pre .preprocessor,
+pre .prepro {
 	color: #a33243;
 }
 pre .global {

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -111,7 +111,7 @@ option {
 input,
 button,
 textarea,
-select {*font-size:100%;
+select {*font-size: 100%;
 }
 /* END RESET */
 
@@ -123,11 +123,11 @@ body {
 }
 
 code, tt { font-family: monospace; font-size: 1.1em; }
-span.parameter { font-family:monospace; }
-span.parameter:after { content:":"; }
-span.types:before { content:"("; }
-span.types:after { content:")"; }
-.type { font-weight: bold; font-style:italic }
+span.parameter { font-family: monospace; }
+span.parameter:after { content: ":"; }
+span.types:before { content: "("; }
+span.types:after { content: ")"; }
+.type { font-weight: bold; font-style: italic }
 
 body, p, td, th { font-size: .95em; line-height: 1.2em;}
 
@@ -151,7 +151,7 @@ a:visited { font-weight: bold; color: #006699; text-decoration: none; }
 a:link:hover { text-decoration: underline; }
 
 hr {
-	color:#cccccc;
+	color: #cccccc;
 	background: #00007f;
 	height: 1px;
 }
@@ -211,18 +211,18 @@ table.index td { text-align: left; vertical-align: top; }
 }
 
 #navigation h2 {
-	background-color:#e7e7e7;
-	font-size:1.1em;
-	color:#000000;
+	background-color: #e7e7e7;
+	font-size: 1.1em;
+	color: #000000;
 	text-align: left;
-	padding:0.2em;
-	border-top:1px solid #dddddd;
-	border-bottom:1px solid #dddddd;
+	padding: 0.2em;
+	border-top: 1px solid #dddddd;
+	border-bottom: 1px solid #dddddd;
 }
 
 #navigation ul
 {
-	font-size:1em;
+	font-size: 1em;
 	list-style-type: none;
 	margin: 1px 1px 10px 1px;
 }
@@ -317,8 +317,8 @@ table.function_list td.name { background-color: #f0f0f0; min-width: 200px; }
 table.function_list td.summary { width: 100%; }
 
 ul.nowrap {
-	overflow:auto;
-	white-space:nowrap;
+	overflow: auto;
+	white-space: nowrap;
 }
 
 dl.table dt, dl.function dt {border-top: 1px solid #ccc; padding-top: 1em;}

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -369,7 +369,6 @@ table.module_list td.summary {
 	width: 100%;
 }
 
-
 table.function_list {
 	border-collapse: collapse;
 	border-color: #ccc;
@@ -428,7 +427,6 @@ ul ol {
 a:target + * {
 	background-color: #ff9;
 }
-
 
 /* styles for prettification of source */
 pre .comment {

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -10,7 +10,7 @@ version: 2.8.2r1
 /* stylelint-disable no-descending-specificity */
 
 html {
-	background: #FFF;
+	background: #fff;
 	color: #000;
 }
 body,

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -5,6 +5,10 @@ Code licensed under the BSD License:
 http://developer.yahoo.com/yui/license.html
 version: 2.8.2r1
 */
+
+/* stylelint-disable selector-no-id */
+/* stylelint-disable no-descending-specificity */
+
 html {
 	background: #FFF;
 	color: #000;

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -121,7 +121,7 @@ body {
 	margin-right: 1em;
 	font-family: arial, helvetica, geneva, sans-serif;
 	background-color: #ffffff;
-	margin: 0px;
+	margin: 0;
 }
 
 code, tt {
@@ -151,7 +151,7 @@ body, p, td, th {
 }
 
 p, ul {
-	margin: 10px 0 0 0px;
+	margin: 10px 0 0 0;
 }
 
 strong {
@@ -282,11 +282,11 @@ table.index td {
 #navigation li {
 	text-indent: -1em;
 	display: block;
-	margin: 3px 0px 0px 22px;
+	margin: 3px 0 0 22px;
 }
 
 #navigation li li a {
-	margin: 0px 3px 0px -1em;
+	margin: 0 3px 0 -1em;
 }
 
 #content {
@@ -317,7 +317,7 @@ table.index td {
 
 	#main {
 		background-color: #ffffff;
-		border-left: 0px;
+		border-left: 0;
 	}
 
 	#container {
@@ -401,16 +401,16 @@ dl.table h3, dl.function h3 {
 
 /* stop sublists from having initial vertical space */
 ul ul {
-	margin-top: 0px;
+	margin-top: 0;
 }
 ol ul {
-	margin-top: 0px;
+	margin-top: 0;
 }
 ol ol {
-	margin-top: 0px;
+	margin-top: 0;
 }
 ul ol {
-	margin-top: 0px;
+	margin-top: 0;
 }
 
 /* make the target distinct; helps when we're navigating to a function */

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -153,7 +153,7 @@ body,
 p,
 td,
 th {
-	font-size: .95em;
+	font-size: 0.95em;
 	line-height: 1.2em;
 }
 
@@ -232,7 +232,7 @@ pre {
 }
 
 pre.example {
-	font-size: .85em;
+	font-size: 0.85em;
 }
 
 table.index {
@@ -409,7 +409,7 @@ dl.function dd {
 }
 dl.table h3,
 dl.function h3 {
-	font-size: .95em;
+	font-size: 0.95em;
 }
 
 /* stop sublists from having initial vertical space */

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -123,9 +123,7 @@ select {
 body {
 	background-color: #fff;
 	font-family: 'arial', 'helvetica', 'geneva', sans-serif;
-	margin: 0;
-	margin-left: 1em;
-	margin-right: 1em;
+	margin: 0 1em 0 1em;
 }
 
 code, tt {

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -6,8 +6,8 @@ http://developer.yahoo.com/yui/license.html
 version: 2.8.2r1
 */
 html {
-    color: #000;
-    background: #FFF;
+	color: #000;
+	background: #FFF;
 }
 body,
 div,
@@ -35,16 +35,16 @@ p,
 blockquote,
 th,
 td {
-    margin: 0;
-    padding: 0;
+	margin: 0;
+	padding: 0;
 }
 table {
-    border-collapse: collapse;
-    border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 fieldset,
 img {
-    border: 0;
+	border: 0;
 }
 address,
 caption,
@@ -56,19 +56,19 @@ strong,
 th,
 var,
 optgroup {
-    font-style: inherit;
-    font-weight: inherit;
+	font-style: inherit;
+	font-weight: inherit;
 }
 del,
 ins {
-    text-decoration: none;
+	text-decoration: none;
 }
 li {
-    margin-left: 20px;
+	margin-left: 20px;
 }
 caption,
 th {
-    text-align: left;
+	text-align: left;
 }
 h1,
 h2,
@@ -76,26 +76,26 @@ h3,
 h4,
 h5,
 h6 {
-    font-size: 100%;
-    font-weight: bold;
+	font-size: 100%;
+	font-weight: bold;
 }
 q:before,
 q:after {
-    content: '';
+	content: '';
 }
 abbr,
 acronym {
-    border: 0;
-    font-variant: normal;
+	border: 0;
+	font-variant: normal;
 }
 sup {
-    vertical-align: baseline;
+	vertical-align: baseline;
 }
 sub {
-    vertical-align: baseline;
+	vertical-align: baseline;
 }
 legend {
-    color: #000;
+	color: #000;
 }
 input,
 button,
@@ -103,10 +103,10 @@ textarea,
 select,
 optgroup,
 option {
-    font-family: inherit;
-    font-size: inherit;
-    font-style: inherit;
-    font-weight: inherit;
+	font-family: inherit;
+	font-size: inherit;
+	font-style: inherit;
+	font-weight: inherit;
 }
 input,
 button,
@@ -116,10 +116,10 @@ select {*font-size:100%;
 /* END RESET */
 
 body {
-    margin-left: 1em;
-    margin-right: 1em;
-    font-family: arial, helvetica, geneva, sans-serif;
-    background-color: #ffffff; margin: 0px;
+	margin-left: 1em;
+	margin-right: 1em;
+	font-family: arial, helvetica, geneva, sans-serif;
+	background-color: #ffffff; margin: 0px;
 }
 
 code, tt { font-family: monospace; font-size: 1.1em; }
@@ -138,8 +138,8 @@ strong { font-weight: bold;}
 em { font-style: italic;}
 
 h1 {
-    font-size: 1.5em;
-    margin: 20px 0 20px 0;
+	font-size: 1.5em;
+	margin: 20px 0 20px 0;
 }
 h2, h3, h4 { margin: 15px 0 10px 0; }
 h2 { font-size: 1.25em; }
@@ -151,9 +151,9 @@ a:visited { font-weight: bold; color: #006699; text-decoration: none; }
 a:link:hover { text-decoration: underline; }
 
 hr {
-    color:#cccccc;
-    background: #00007f;
-    height: 1px;
+	color:#cccccc;
+	background: #00007f;
+	height: 1px;
 }
 
 blockquote { margin-left: 3em; }
@@ -161,164 +161,164 @@ blockquote { margin-left: 3em; }
 ul { list-style-type: disc; }
 
 p.name {
-    font-family: "Andale Mono", monospace;
-    padding-top: 1em;
+	font-family: "Andale Mono", monospace;
+	padding-top: 1em;
 }
 
 pre {
-    background-color: rgb(245, 245, 245);
-    border: 1px solid #C0C0C0; /* silver */
-    padding: 10px;
-    margin: 10px 0 10px 0;
-    overflow: auto;
-    font-family: "Andale Mono", monospace;
+	background-color: rgb(245, 245, 245);
+	border: 1px solid #C0C0C0; /* silver */
+	padding: 10px;
+	margin: 10px 0 10px 0;
+	overflow: auto;
+	font-family: "Andale Mono", monospace;
 }
 
 pre.example {
-    font-size: .85em;
+	font-size: .85em;
 }
 
 table.index { border: 1px #00007f; }
 table.index td { text-align: left; vertical-align: top; }
 
 #container {
-    margin-left: 1em;
-    margin-right: 1em;
-    background-color: #f0f0f0;
+	margin-left: 1em;
+	margin-right: 1em;
+	background-color: #f0f0f0;
 }
 
 #product {
-    text-align: center;
-    border-bottom: 1px solid #cccccc;
-    background-color: #ffffff;
+	text-align: center;
+	border-bottom: 1px solid #cccccc;
+	background-color: #ffffff;
 }
 
 #product big {
-    font-size: 2em;
+	font-size: 2em;
 }
 
 #main {
-    background-color: #f0f0f0;
-    border-left: 2px solid #cccccc;
+	background-color: #f0f0f0;
+	border-left: 2px solid #cccccc;
 }
 
 #navigation {
-    float: left;
-    width: 14em;
-    vertical-align: top;
-    background-color: #f0f0f0;
-    overflow: visible;
+	float: left;
+	width: 14em;
+	vertical-align: top;
+	background-color: #f0f0f0;
+	overflow: visible;
 }
 
 #navigation h2 {
-    background-color:#e7e7e7;
-    font-size:1.1em;
-    color:#000000;
-    text-align: left;
-    padding:0.2em;
-    border-top:1px solid #dddddd;
-    border-bottom:1px solid #dddddd;
+	background-color:#e7e7e7;
+	font-size:1.1em;
+	color:#000000;
+	text-align: left;
+	padding:0.2em;
+	border-top:1px solid #dddddd;
+	border-bottom:1px solid #dddddd;
 }
 
 #navigation ul
 {
-    font-size:1em;
-    list-style-type: none;
-    margin: 1px 1px 10px 1px;
+	font-size:1em;
+	list-style-type: none;
+	margin: 1px 1px 10px 1px;
 }
 
 #navigation li {
-    text-indent: -1em;
-    display: block;
-    margin: 3px 0px 0px 22px;
+	text-indent: -1em;
+	display: block;
+	margin: 3px 0px 0px 22px;
 }
 
 #navigation li li a {
-    margin: 0px 3px 0px -1em;
+	margin: 0px 3px 0px -1em;
 }
 
 #content {
-    margin-left: 14em;
-    padding: 1em;
-    width: 700px;
-    border-left: 2px solid #cccccc;
-    border-right: 2px solid #cccccc;
-    background-color: #ffffff;
+	margin-left: 14em;
+	padding: 1em;
+	width: 700px;
+	border-left: 2px solid #cccccc;
+	border-right: 2px solid #cccccc;
+	background-color: #ffffff;
 }
 
 #about {
-    clear: both;
-    padding: 5px;
-    border-top: 2px solid #cccccc;
-    background-color: #ffffff;
+	clear: both;
+	padding: 5px;
+	border-top: 2px solid #cccccc;
+	background-color: #ffffff;
 }
 
 @media print {
-    body {
-        font: 12pt "Times New Roman", "TimeNR", Times, serif;
-    }
-    a { font-weight: bold; color: #004080; text-decoration: underline; }
+	body {
+		font: 12pt "Times New Roman", "TimeNR", Times, serif;
+	}
+	a { font-weight: bold; color: #004080; text-decoration: underline; }
 
-    #main {
-        background-color: #ffffff;
-        border-left: 0px;
-    }
+	#main {
+		background-color: #ffffff;
+		border-left: 0px;
+	}
 
-    #container {
-        margin-left: 2%;
-        margin-right: 2%;
-        background-color: #ffffff;
-    }
+	#container {
+		margin-left: 2%;
+		margin-right: 2%;
+		background-color: #ffffff;
+	}
 
-    #content {
-        padding: 1em;
-        background-color: #ffffff;
-    }
+	#content {
+		padding: 1em;
+		background-color: #ffffff;
+	}
 
-    #navigation {
-        display: none;
-    }
-    pre.example {
-        font-family: "Andale Mono", monospace;
-        font-size: 10pt;
-        page-break-inside: avoid;
-    }
+	#navigation {
+		display: none;
+	}
+	pre.example {
+		font-family: "Andale Mono", monospace;
+		font-size: 10pt;
+		page-break-inside: avoid;
+	}
 }
 
 table.module_list {
-    border-width: 1px;
-    border-style: solid;
-    border-color: #cccccc;
-    border-collapse: collapse;
+	border-width: 1px;
+	border-style: solid;
+	border-color: #cccccc;
+	border-collapse: collapse;
 }
 table.module_list td {
-    border-width: 1px;
-    padding: 3px;
-    border-style: solid;
-    border-color: #cccccc;
+	border-width: 1px;
+	padding: 3px;
+	border-style: solid;
+	border-color: #cccccc;
 }
 table.module_list td.name { background-color: #f0f0f0; min-width: 200px; }
 table.module_list td.summary { width: 100%; }
 
 
 table.function_list {
-    border-width: 1px;
-    border-style: solid;
-    border-color: #cccccc;
-    border-collapse: collapse;
+	border-width: 1px;
+	border-style: solid;
+	border-color: #cccccc;
+	border-collapse: collapse;
 }
 table.function_list td {
-    border-width: 1px;
-    padding: 3px;
-    border-style: solid;
-    border-color: #cccccc;
+	border-width: 1px;
+	padding: 3px;
+	border-style: solid;
+	border-color: #cccccc;
 }
 table.function_list td.name { background-color: #f0f0f0; min-width: 200px; }
 table.function_list td.summary { width: 100%; }
 
 ul.nowrap {
-    overflow:auto;
-    white-space:nowrap;
+	overflow:auto;
+	white-space:nowrap;
 }
 
 dl.table dt, dl.function dt {border-top: 1px solid #ccc; padding-top: 1em;}
@@ -333,7 +333,7 @@ ul ol { margin-top: 0px; }
 
 /* make the target distinct; helps when we're navigating to a function */
 a:target + * {
-  background-color: #FF9;
+	background-color: #FF9;
 }
 
 

--- a/doc/ldoc.css
+++ b/doc/ldoc.css
@@ -132,13 +132,13 @@ span.parameter {
 	font-family: monospace;
 }
 span.parameter:after {
-	content: ":";
+	content: ':';
 }
 span.types:before {
-	content: "(";
+	content: '(';
 }
 span.types:after {
-	content: ")";
+	content: ')';
 }
 .type {
 	font-weight: bold;
@@ -208,7 +208,7 @@ ul {
 }
 
 p.name {
-	font-family: "Andale Mono", monospace;
+	font-family: 'Andale Mono', monospace;
 	padding-top: 1em;
 }
 
@@ -218,7 +218,7 @@ pre {
 	padding: 10px;
 	margin: 10px 0 10px 0;
 	overflow: auto;
-	font-family: "Andale Mono", monospace;
+	font-family: 'Andale Mono', monospace;
 }
 
 pre.example {
@@ -307,7 +307,7 @@ table.index td {
 
 @media print {
 	body {
-		font: 12pt "Times New Roman", "TimeNR", Times, serif;
+		font: 12pt 'Times New Roman', 'TimeNR', 'Times', serif;
 	}
 	a {
 		font-weight: bold;
@@ -335,7 +335,7 @@ table.index td {
 		display: none;
 	}
 	pre.example {
-		font-family: "Andale Mono", monospace;
+		font-family: 'Andale Mono', monospace;
 		font-size: 10pt;
 		page-break-inside: avoid;
 	}


### PR DESCRIPTION
The stylelint defs in use by WMF is pretty stringent, and the changes makes `ldoc.css` pass them. Additional cleanups should be done, but this is the bare minimum to avoid warnings during the build process.

The defs should be nearly identical, but please check if something visually breaks.