### PR TITLE
Test _wrapped value using rawget

### DIFF
--- a/moses.lua
+++ b/moses.lua
@@ -2208,7 +2208,7 @@ do
   -- Register all functions into the wrapper
   for fname,fct in pairs(_) do
     f[fname] = function(v, ...)
-      local wrapped = _.isTable(v) and v._wrapped or false
+      local wrapped = _.isTable(v) and rawget(v,'_wrapped') or false
       if wrapped then
         local _arg = v._value
         local _rslt = fct(_arg,...)


### PR DESCRIPTION
The current check against _wrapped breaks if the table provided has a metatable which returns anything other than nil or false for unset keys. Using rawget mitigates against this. 

Compare before and after using the following:
```
_.keys(setmetatable({a='test'},{
  __index=function(t,k)
    return ''
  end
}))
```