### PR TITLE
Fix `chunk` with identity as chunking function

### DIFF
--- a/moses.lua
+++ b/moses.lua
@@ -1204,8 +1204,8 @@ function M.chunk(array, f)
   local ch, ck, prev, val = {}, 0
   for k,v in ipairs(array) do
     val = f(v, k)
-    prev = (prev==nil) and val or prev
     ck = ((val~=prev) and (ck+1) or ck)
+    prev = (prev==nil) and val or prev
     if not ch[ck] then
       ch[ck] = {array[k]}
     else

--- a/spec/array_spec.lua
+++ b/spec/array_spec.lua
@@ -380,6 +380,17 @@ describe('Array functions specs', function()
       assert.is_true(M.isEqual(v[3], {3,3}))
       assert.is_true(M.isEqual(v[4], {4,4}))             
     end)  
+
+    it('chunks in blocks consecutive values when using identity as function', function()
+      local t = {1,1,2,2,3,3,4}
+      local v = M.chunk(t, function(v) return v end)
+      assert.is_nil(v[0])
+      assert.equal(#v, 4)
+      assert.is_true(M.isEqual(v[1], {1,1}))
+      assert.is_true(M.isEqual(v[2], {2,2}))
+      assert.is_true(M.isEqual(v[3], {3,3}))
+      assert.is_true(M.isEqual(v[4], {4}))
+    end)  
     
   end)
   


### PR DESCRIPTION
I'm very new to Lua but it seems like `chunk` is somewhat broken when using the identity function for chunking. Specifically it writes elements to `ch[0]` when instead they should be written to `ch[1]`. 

I added a failing test case for this particular situation but don't fully understand how the `chunk` code works (new to Lua) so haven't tried to fix it yet.